### PR TITLE
[release] Validate release target paths, use /targets/release base dir for all releases

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/werf/vault-plugin-secrets-trdl
 go 1.16
 
 require (
+	github.com/Masterminds/semver v1.5.0 // indirect
 	github.com/aws/aws-sdk-go v1.30.27
 	github.com/docker/distribution v2.7.1+incompatible // indirect
 	github.com/docker/docker v1.4.2-0.20200319182547-c7ad2b866182

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 h1:w+iIsaOQNcT7O
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
+github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
+github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
 github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5/go.mod h1:tTuCMEN+UleMWgg9dVx4Hu52b1bJo+59jBh3ajtinzw=
 github.com/Microsoft/go-winio v0.4.16 h1:FtSW/jqD+l4ba5iPBj9CODVtgfYAD8w2wS923g/cFDk=

--- a/pkg/publisher/helpers.go
+++ b/pkg/publisher/helpers.go
@@ -5,7 +5,12 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 	"path/filepath"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/Masterminds/semver"
 )
 
 type InMemoryFile struct {
@@ -13,9 +18,41 @@ type InMemoryFile struct {
 	Data []byte
 }
 
-func PublishReleaseTarget(ctx context.Context, repository *S3Repository, releaseName, path string, data io.Reader) error {
-	return repository.PublishTarget(ctx, filepath.Join(releaseName, path), data)
+func NewErrIncorrectTargetPath(path string) error {
+	return fmt.Errorf(`got incorrect target path %q: expected path in format <os>-<arch>/... where os can be either "any", "linux", "darwin" or "windows", and arch can be either "any", "amd64" or "arm64"`, path)
 }
+
+func PublishReleaseTarget(ctx context.Context, repository *S3Repository, releaseName, path string, data io.Reader) error {
+	_, err := semver.NewVersion(releaseName)
+	if err != nil {
+		return fmt.Errorf("expected semver release name got %q: %s", releaseName, err)
+	}
+
+	pathParts := SplitFilepath(filepath.Clean(path))
+	if len(pathParts) == 0 {
+		return NewErrIncorrectTargetPath(path)
+	}
+
+	osAndArchParts := strings.SplitN(pathParts[0], "-", 2)
+
+	switch osAndArchParts[0] {
+	case "any", "linux", "darwin", "windows":
+	default:
+		return NewErrIncorrectTargetPath(path)
+	}
+
+	switch osAndArchParts[1] {
+	case "any", "amd64", "arm64":
+	default:
+		return NewErrIncorrectTargetPath(path)
+	}
+
+	return repository.PublishTarget(ctx, filepath.Join("releases", releaseName, path), data)
+}
+
+// func PublishChannelsTarget(ctx context.Context, repository *S3Repository, releaseName, path string, data io.Reader) error {
+// 	return fmt.Errorf("not implemented")
+// }
 
 func PublishInMemoryFiles(ctx context.Context, repository *S3Repository, files []*InMemoryFile) error {
 	for _, file := range files {
@@ -24,4 +61,68 @@ func PublishInMemoryFiles(ctx context.Context, repository *S3Repository, files [
 		}
 	}
 	return nil
+}
+
+// TODO: move this to the separate project in github.com/werf
+func SplitFilepath(path string) (result []string) {
+	path = filepath.FromSlash(path)
+	separator := os.PathSeparator
+
+	idx := 0
+	if separator == '\\' {
+		// if the separator is '\\', then we can just split...
+		result = strings.Split(path, string(separator))
+		idx = len(result)
+	} else {
+		// otherwise, we need to be careful of situations where the separator was escaped
+		cnt := strings.Count(path, string(separator))
+		if cnt == 0 {
+			return []string{path}
+		}
+
+		result = make([]string, cnt+1)
+		pathlen := len(path)
+		separatorLen := utf8.RuneLen(separator)
+		emptyEnd := false
+		for start := 0; start < pathlen; {
+			end := indexRuneWithEscaping(path[start:], separator)
+			if end == -1 {
+				emptyEnd = false
+				end = pathlen
+			} else {
+				emptyEnd = true
+				end += start
+			}
+			result[idx] = path[start:end]
+			start = end + separatorLen
+			idx++
+		}
+
+		// If the last rune is a path separator, we need to append an empty string to
+		// represent the last, empty path component. By default, the strings from
+		// make([]string, ...) will be empty, so we just need to increment the count
+		if emptyEnd {
+			idx++
+		}
+	}
+
+	return result[:idx]
+}
+
+// TODO: move this to the separate project in github.com/werf
+// Find the first index of a rune in a string,
+// ignoring any times the rune is escaped using "\".
+func indexRuneWithEscaping(s string, r rune) int {
+	end := strings.IndexRune(s, r)
+	if end == -1 {
+		return -1
+	}
+	if end > 0 && s[end-1] == '\\' {
+		start := end + utf8.RuneLen(r)
+		end = indexRuneWithEscaping(s[start:], r)
+		if end != -1 {
+			end += start
+		}
+	}
+	return end
 }


### PR DESCRIPTION
 - `/targets/release/SEMVER/` directory will contain release named by `SEMVER`;
 - each release directory should contain following directory structure:
    - `OS-ARCH/bin/BINARY_FILE` where `OS` can be `linux`, `windows`, `darwin` or `any`, and `ARCH` can be `amd64` or `arm64`.