### PR TITLE
fix: remove "v" letter from release name in the tuf repo files

### DIFF
--- a/pkg/publisher/publisher.go
+++ b/pkg/publisher/publisher.go
@@ -170,11 +170,6 @@ func (publisher *Publisher) StageReleaseTarget(ctx context.Context, repository R
 	publisher.mu.Lock()
 	defer publisher.mu.Unlock()
 
-	_, err := semver.NewVersion(releaseName)
-	if err != nil {
-		return fmt.Errorf("expected semver release name got %q: %s", releaseName, err)
-	}
-
 	pathParts := SplitFilepath(filepath.Clean(path))
 	if len(pathParts) == 0 {
 		return NewErrIncorrectTargetPath(path)


### PR DESCRIPTION
v1.2.13 git tag version will generate `/targets/releases/1.2.13/...` directory in the tuf repository files structure.